### PR TITLE
prevented reinitializing constants by setting LOADED variable

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,20 +8,25 @@ require File.expand_path(File.join('..', '..', 'lib', 'web'), __FILE__)
 ENV['RACK_ENV'] = 'test'
 
 module LocationFixtures
-  CHESTNUT_HILL                 = "19118"
-  CHESTNUT_HILL_BAR_COUNT       = 9
-  CHESTNUT_HILL_SCORE           = 45.0
-  CHESTNUT_HILL_CLASSIFICATION  = "Tipsy"
-  CHESTNUT_HILL_BAR             = "Towey's Tavern"
-  PAOLI                         = "19301"
-  PAOLI_BAR_COUNT               = 5
-  PAOLI_SCORE                   = 25.0
-  PAOLI_CLASSIFICATION          = "Dry"
-  PAOLI_BAR                     = "The Great American Pub"
-  RITTENHOUSE                   = "19103"
-  RITTENHOUSE_BAR_COUNT         = 20
-  RITTENHOUSE_SCORE             = 100.0
-  RITTENHOUSE_CLASSIFICATION    = "Sloppy"
-  RITTENHOUSE_BAR               = "Drinker's Pub"
+  if ! (LOADED rescue false)
+    
+    CHESTNUT_HILL                 = "19118"
+    CHESTNUT_HILL_BAR_COUNT       = 9
+    CHESTNUT_HILL_SCORE           = 45.0
+    CHESTNUT_HILL_CLASSIFICATION  = "Tipsy"
+    CHESTNUT_HILL_BAR             = "Towey's Tavern"
+    PAOLI                         = "19301"
+    PAOLI_BAR_COUNT               = 5
+    PAOLI_SCORE                   = 25.0
+    PAOLI_CLASSIFICATION          = "Dry"
+    PAOLI_BAR                     = "The Great American Pub"
+    RITTENHOUSE                   = "19103"
+    RITTENHOUSE_BAR_COUNT         = 20
+    RITTENHOUSE_SCORE             = 100.0
+    RITTENHOUSE_CLASSIFICATION    = "Sloppy"
+    RITTENHOUSE_BAR               = "Drinker's Pub"
+
+    LOADED = true
+  end
 end
 


### PR DESCRIPTION
This fix is similar to how you fix this problem in C++. It’s probably not the best way. What I really want is something like PHP’s require_once, but I’m not sure how to do that in Ruby. Another similar existing tools is config/initializers in Rails, and sinatra-initializers (https://github.com/chadwpry/sinatra-initializers), but then it would initialize those constants outside of the tests, too, which is not ideal.

The possible future fix might also relate to the encapsulation of the `require File.expand_path` pattern into some kind of require_relative_path method.

A possible slight improvement would be to require ActiveSupport’s active_support/core_ext/kernel/reporting.rb and use suppress to suppress only a NameError, not any error.
